### PR TITLE
initial add README and a README for the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Project Template
+
+A template for all ECE USC Open Source project repos! 
+
+
+## What is this?
+
+In our GitHub organization, [@eceusc](https://github.com/eceusc), we have a lot of repositories. Only a few of these repos are "project" repositories, meant specifically for an ECE USC Open Source Project (which are prefixed with `project-`). We want to standardize a few things about these project repositories (e.g., `README` structure, `LICENSE`, `CODE_OF_CONDUCT`, etc. So, this repo has a tool to do just that!
+
+
+## Usage
+
+### Templatize a new project repo
+
+
+### Templatize an existing repo
+

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,69 @@
+# Project Example Name
+
+A quick tagline explanation with the project emoji! :notebook:
+
+\<NOTE: this template is mostly a suggestion, nothing here is mandatory. Feel free to change the structure or writing style in your actual repo.\>
+
+## About
+
+This paragraph (1-2 sentences) is a high-level non-technical overview of what the project is meant to do. 
+
+This paragraph (1-2 sentences) is a more technical overview of how the project works (devices, programming languages, tools, hosting services, etc.). 
+
+## Getting Started
+
+This section is a short, technical tutorial on how to clone, setup, and run the project.
+
+### Quick Demo
+
+If possible, have a "Deploy to Heroku", "Edit with Glitch". 
+
+
+### Prerequisites
+
+If someone wants to run this project, do they need to install thing? This can be a quick 1 sentence saying something like "To run this project, make sure that:" followed by a numbered list like
+
+1. Have [Python3 installed](https://www.python.org/downloads/)
+2. Have [Pip installed](https://pip.pypa.io/en/stable/installing/)
+3. Have a [Glitch account](https://www.glitch.com)
+
+\<NOTE: Link to download pages/tutorials for each thing you list. And, if possible, try to link to something that explains how to download the thing in many different operating systems (Windows, Mac, Linux, etc.)\>
+
+### Installing
+
+Quick 1-2 sentences saying where to run these commands (terminal, git bash on Windows, etc.)
+
+\`\`\`shell
+
+git clone https://github.com/eceusc/project-example.git
+cd project-example
+virtualenv venv
+./venv/bin/start
+pip install -r requirements.txt
+python3 main.py
+\`\`\`
+
+Then, 1 sentence to show what they should see after running the above:
+
+\`\`\`shell
+$ python3 main.py
+Example server running on port 3000!
+\`\`\`
+
+\<Optional: if a webserver, a [link](http://localhost:3000) to the localhost port where their project should be running
+
+
+### Troubleshooting
+(bc they probably will have trouble running the above)
+
+Something like "If you have trouble install the above, try:"
+
+1. Make sure python is installed correctly
+2. Make sure pip is installed
+3. If \<insert common error\>, try: doing X or Y
+
+"If you still cant figure it out, ask for help in the #help slack channel!
+
+
+## Contributing
+


### PR DESCRIPTION
Right now, this eceusc/project-template repo is empty. This PR gives a README as well as a README for the actual template. 

This repo will act as a template for all ECE USC project repos. For example, `project-vending-machine` and `project-messenger-bot` will both use the template from this repository in order to make things consistence (README structure, same license, etc.)

pls approve